### PR TITLE
Require silex ~1.0 as a standard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,12 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "intouch/newrelic": "1.0.2"
+        "intouch/newrelic": "1.0.2",
+        "silex/silex": "~1.0"
     },
     "require-dev": {
         "mockery/mockery": "0.8.0",
-        "phpunit/phpunit": "3.7.*",
-        "silex/silex": "*"
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This package requires files provided by Silex, and therefore should depend on it.

Also, it only works with versions 1.0 - 1.3, since [version 2.0 changes the location of a critical interface](https://github.com/silexphp/Silex/commit/1ba15a1769979083b19d775237fa0cfefb1475fe).  (The build is currently failing because it tests against the 2.x dev branch)